### PR TITLE
Added PathfinderController unit tests, cleaned up unit test order

### DIFF
--- a/Pathfinder/Models/PathfinderService.cs
+++ b/Pathfinder/Models/PathfinderService.cs
@@ -30,7 +30,6 @@
         /// <exception cref="ArgumentException">Exception thrown for an invalid country code input.</exception>
         public List<string> FindPath(string destination)
         {
-            destination = destination.ToUpper();
             // Validate the input
             if (string.IsNullOrWhiteSpace((destination)))
             {
@@ -41,6 +40,9 @@
             {
                 throw new ArgumentException($"Invalid country code {destination}");
             }
+
+            // Normalize input to the capital letters we expect in our dictionary
+            destination = destination.ToUpper();
 
             // BFS Search for desired country
             List<string> traversedCountries = new();

--- a/Pathfinder_UnitTests/PathfinderControllerTests.cs
+++ b/Pathfinder_UnitTests/PathfinderControllerTests.cs
@@ -1,0 +1,102 @@
+﻿using Microsoft.AspNetCore.Mvc;
+
+namespace Pathfinder_UnitTests
+{
+    /// <summary>
+    /// These are unit tests for the controller, PathfinderController.
+    /// These are similar to the unit tests for the controller, but we expect HTTP responses and we do not expect exceptions to be thrown.
+    /// </summary>
+    public class PathfinderControllerTests
+    {
+        #region FindPath() Tests
+        public static IEnumerable<object[]> GetPathTestData()
+        {
+            yield return new object[] { "PAN", new List<string> { "USA", "MEX", "GTM", "HND", "NIC", "CRI", "PAN" } };
+            yield return new object[] { "BLZ", new List<string> { "USA", "MEX", "BLZ" } };
+            yield return new object[] { "CAN", new List<string> { "USA", "CAN" } };
+        }
+
+        #region Returns 200 Ok
+
+        [Theory]
+        [MemberData(nameof(GetPathTestData))]
+        public void FindPath_CountryCode_Returns200ValidPath(string countryCode, List<string> expectedResult)
+        {
+            // Arrange
+            var pathfinderController = PathfinderSetup.GetController();
+
+            // Act
+            var result = pathfinderController.FindPath(countryCode) as OkObjectResult;
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal(200, result.StatusCode);
+            Assert.Equal(expectedResult, result.Value);
+        }
+
+        [Fact]
+        public void FindPath_StartPoint_Returns200Start()
+        {
+            // Arrange
+            var pathfinderController = PathfinderSetup.GetController();
+            var startLocation = "USA";
+
+            // Act
+            var result = pathfinderController.FindPath(startLocation) as OkObjectResult;
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal(200, result.StatusCode);
+            Assert.Equal(new List<string> { "USA" }, result.Value);
+        }
+        #endregion
+
+        #region 400 Bad Request
+        [Fact]
+        public void FindPath_Null_Returns400()
+        {
+            // Arrange
+            var pathfinderController = PathfinderSetup.GetController();
+
+            // Act
+            var result = pathfinderController.FindPath(null) as ObjectResult;
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal(400, result.StatusCode);
+        }
+
+        [Fact]
+        public void FindPath_EmptyString_Returns400()
+        {
+            // Arrange
+            var pathfinderController = PathfinderSetup.GetController();
+
+            // Act
+            var result = pathfinderController.FindPath(string.Empty) as ObjectResult;
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal(400, result.StatusCode);
+        }
+
+        [Theory]
+        [InlineData("A")]
+        [InlineData("USD")]
+        public void FindPath_InvalidCountryCodes_Returns400(string invalidCountryCode)
+        {
+            // Arrange
+            var pathfinderController = PathfinderSetup.GetController();
+
+            // Act
+            var result = pathfinderController.FindPath(invalidCountryCode) as ObjectResult;
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal(400, result.StatusCode);
+        }
+        #endregion
+
+        #endregion
+    }
+}

--- a/Pathfinder_UnitTests/PathfinderServiceTests.cs
+++ b/Pathfinder_UnitTests/PathfinderServiceTests.cs
@@ -9,6 +9,7 @@ namespace Pathfinder_UnitTests
     public class PathfinderServiceTests
     {
         #region FindPath() Tests
+
         public static IEnumerable<object[]> GetPathTestData()
         {
             yield return new object[] { "PAN", new List<string> { "USA", "MEX", "GTM", "HND", "NIC", "CRI", "PAN" } };
@@ -16,6 +17,7 @@ namespace Pathfinder_UnitTests
             yield return new object[] { "CAN", new List<string> { "USA", "CAN" } };
         }
 
+        #region Successes
         [Theory]
         [MemberData(nameof(GetPathTestData))]
         public void FindPath_CountryCode_ReturnsValidPath(string countryCode, List<string> expectedResult)
@@ -27,9 +29,29 @@ namespace Pathfinder_UnitTests
             var result = pathfinderSvc.FindPath(countryCode);
 
             // Assert
+            Assert.NotNull(result);
             Assert.Equal(expectedResult, result);
         }
 
+        [Fact]
+        public void FindPath_StartPoint_ReturnsStart()
+        {
+            // Arrange
+            var pathfinderSvc = new PathfinderService();
+            var startLocation = "USA";
+
+            // Act
+            var result = pathfinderSvc.FindPath(startLocation);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal(1, result.Count);
+            Assert.Equal(["USA"], result);
+        }
+
+        #endregion
+
+        #region Exceptions
         [Fact]
         public void FindPath_Null_ThrowsException()
         {
@@ -61,21 +83,8 @@ namespace Pathfinder_UnitTests
             // Act & Assert
             Assert.Throws<ArgumentException>(() => pathfinderSvc.FindPath(invalidCountryCode));
         }
+        #endregion
 
-        [Fact]
-        public void FindPath_StartPoint_ReturnsStart()
-        {
-            // Arrange
-            var pathfinderSvc = new PathfinderService();
-            var startLocation = "USA";
-
-            // Act
-            var result = pathfinderSvc.FindPath(startLocation);
-
-            // Assert
-            Assert.Equal(1, result.Count);
-            Assert.Equal(["USA"], result);
-        }
         #endregion
     }
 }

--- a/Pathfinder_UnitTests/PathfinderSetup.cs
+++ b/Pathfinder_UnitTests/PathfinderSetup.cs
@@ -1,0 +1,14 @@
+﻿using PathfinderApi.Controllers;
+using PathfinderApi.Models;
+
+namespace Pathfinder_UnitTests
+{
+    public static class PathfinderSetup
+    {
+        public static PathfinderController GetController()
+        {
+            PathfinderService pathfinderSvc = new();
+            return new PathfinderController(pathfinderSvc);
+        }
+    }
+}


### PR DESCRIPTION
- Added unit tests for PathfinderController
- Cleaned up order of unit tests
- I previously made sure to normalize capitalization of input for the FindPath() method. I added this in before my null check, so an unexpected error would occur as the code would try to convert null to uppercase. This normalization was moved to after this null/whitespace check to fix this.