### PR TITLE
Developers/andrew.clayton/code cleanup

### DIFF
--- a/Pathfinder/Controllers/PathfinderController.cs
+++ b/Pathfinder/Controllers/PathfinderController.cs
@@ -3,14 +3,22 @@ using PathfinderApi.Models;
 
 namespace PathfinderApi.Controllers
 {
+    /// <summary>
+    /// This is a controller for our Pathfinder API.
+    /// </summary>
+    /// <param name="pathfinderService"></param>
     [Route("/Countries")]
     [ApiController]
     public class PathfinderController(IPathfinderService pathfinderService) : ControllerBase
     {
         private readonly IPathfinderService _pathfinderSvc = pathfinderService;
-        
 
-        // We have our endpoint for request/response for the country codes
+
+        /// <summary>
+        /// This method is to map a trip to the specified destination, from a default starting point.
+        /// </summary>
+        /// <param name="countryCode">3-character string of a North American country code to reach (ex: CAN).</param>
+        /// <returns>A list of strings representing the countries that must be passed through to reach the destination, in that order.</returns>
         [HttpGet("Path/{countryCode}")]
         public IActionResult FindPath(string countryCode)
         {

--- a/Pathfinder/Controllers/PathfinderController.cs
+++ b/Pathfinder/Controllers/PathfinderController.cs
@@ -1,5 +1,5 @@
 ﻿using Microsoft.AspNetCore.Mvc;
-using PathfinderApi.Models;
+using Pathfinder.Models;
 
 namespace PathfinderApi.Controllers
 {

--- a/Pathfinder/Models/IPahfinderService.cs
+++ b/Pathfinder/Models/IPahfinderService.cs
@@ -1,7 +1,0 @@
-﻿namespace PathfinderApi.Models
-{
-    public interface IPathfinderService
-    {
-        public List<string> FindPath(string destination);
-    }
-}

--- a/Pathfinder/Models/IPathfinderService.cs
+++ b/Pathfinder/Models/IPathfinderService.cs
@@ -1,4 +1,4 @@
-﻿namespace PathfinderApi.Models
+﻿namespace Pathfinder.Models
 {
     /// <summary>
     /// This is an interface for the PathfinderService, which could be implemented in different ways.

--- a/Pathfinder/Models/IPathfinderService.cs
+++ b/Pathfinder/Models/IPathfinderService.cs
@@ -1,0 +1,15 @@
+﻿namespace PathfinderApi.Models
+{
+    /// <summary>
+    /// This is an interface for the PathfinderService, which could be implemented in different ways.
+    /// </summary>
+    public interface IPathfinderService
+    {
+        /// <summary>
+        /// FindPath is to map a trip to the specified destination, from a default starting point.
+        /// </summary>
+        /// <param name="destination">3-character string of a North American country code to reach (ex: CAN).</param>
+        /// <returns>A list of strings representing the countries that must be passed through to reach the destination, in that order.</returns>
+        List<string> FindPath(string destination);
+    }
+}

--- a/Pathfinder/Models/PathfinderConfiguration.cs
+++ b/Pathfinder/Models/PathfinderConfiguration.cs
@@ -1,0 +1,14 @@
+﻿namespace Pathfinder.Models
+{
+    public class PathfinderConfiguration
+    {
+        public string InitialCountry { get; set; }
+        public Dictionary<string, List<string>> AdjacencyList { get; set; }
+
+        public PathfinderConfiguration(string initialCountry, Dictionary<string, List<string>> adjacencyList)
+        {
+            InitialCountry = initialCountry;
+            AdjacencyList = adjacencyList;
+        }
+    }
+}

--- a/Pathfinder/Models/PathfinderService.cs
+++ b/Pathfinder/Models/PathfinderService.cs
@@ -1,26 +1,23 @@
-﻿namespace PathfinderApi.Models
+﻿using Microsoft.Extensions.Options;
+
+namespace Pathfinder.Models
 {
     /// <summary>
-    /// This static class is used to find paths between countries in North America.
+    /// This class is used to find paths between countries in North America. The configuration is pulled from appsettings.json.
     /// </summary>
-    public class PathfinderService : IPathfinderService
+    /// <param name="config">This configuration determines what the adjacency list for countries are, and the starting point for a path.</param>
+    public class PathfinderService(IOptions<PathfinderConfiguration> config) : IPathfinderService
     {
-        // todo: move out to configuration
-        private readonly Dictionary<string, List<string>> AdjacencyList = new()
-        {
-            ["CAN"] = ["USA"],
-            ["USA"] = ["CAN", "MEX"],
-            ["MEX"] = ["USA", "GTM", "BLZ"],
-            ["BLZ"] = ["MEX", "GTM"],
-            ["GTM"] = ["MEX", "BLZ", "SLV", "HND"],
-            ["SLV"] = ["GTM", "HND"],
-            ["HND"] = ["GTM", "SLV", "NIC"],
-            ["NIC"] = ["HND", "CRI"],
-            ["CRI"] = ["NIC", "PAN"],
-            ["PAN"] = ["CRI"]
-        };
+        /// <summary>
+        /// This is an adjacency list, with countries as keys, and bordering countries as values.
+        /// This is how we can traverse through various countries to build our path.
+        /// </summary>
+        private readonly Dictionary<string, List<string>> _adjacencyList = config.Value.AdjacencyList; // todo: add xml comments
 
-        private static readonly string InitialCountry = "USA"; // todo: move out to configuration
+        /// <summary>
+        /// This is the starting point for any given path.
+        /// </summary>
+        private readonly string _initialCountry = config.Value.InitialCountry;
 
         /// <summary>
         /// Returns a list of strings representing the countries that must be passed through to reach a destination.
@@ -36,7 +33,7 @@
                 throw new ArgumentNullException("destination country code cannot be null or empty");
             }
 
-            if (!AdjacencyList.ContainsKey(destination))
+            if (!_adjacencyList.ContainsKey(destination))
             {
                 throw new ArgumentException($"Invalid country code {destination}");
             }
@@ -50,7 +47,7 @@
 
             // In our BFS queue, we will store the current country and the countries visited up to that point.
             Queue<(string, List<string>)> bfsQueue = new();
-            bfsQueue.Enqueue((InitialCountry, []));
+            bfsQueue.Enqueue((_initialCountry, []));
 
             // BFS
             while (bfsQueue.Count > 0)
@@ -64,7 +61,7 @@
 
                 // We have not reached the country we were looking for
                 visitedCountries.Add(currentCountry);
-                foreach (var adjacentCountry in AdjacencyList[currentCountry])
+                foreach (var adjacentCountry in _adjacencyList[currentCountry])
                 {
                     // Add each neighboring country to our queue to search (unless we have already visited it)
                     if (!visitedCountries.Contains(adjacentCountry))

--- a/Pathfinder/Models/PathfinderService.cs
+++ b/Pathfinder/Models/PathfinderService.cs
@@ -20,12 +20,12 @@
             ["PAN"] = ["CRI"]
         };
 
-        private static readonly string InitialCountry = "USA";
+        private static readonly string InitialCountry = "USA"; // todo: move out to configuration
 
         /// <summary>
         /// Returns a list of strings representing the countries that must be passed through to reach a destination.
         /// </summary>
-        /// <param name="destination">The three-character code of a North American country to be reached.</param>
+        /// <param name="destination">3-character string of a North American country code to reach (ex: CAN).</param>
         /// <exception cref="ArgumentNullException">Exception thrown for empty/whitespace input.</exception>
         /// <exception cref="ArgumentException">Exception thrown for an invalid country code input.</exception>
         public List<string> FindPath(string destination)
@@ -75,7 +75,7 @@
             }
 
             // If we have reached this point, the BFS finished without finding our destination country.
-            throw new InvalidOperationException($"Path could not be found for country code {destination}"); // todo: use a logger
+            throw new InvalidOperationException($"Path could not be found for country code {destination}");
         }
     }
 }

--- a/Pathfinder/Program.cs
+++ b/Pathfinder/Program.cs
@@ -1,4 +1,4 @@
-using PathfinderApi.Models;
+using Pathfinder.Models;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -8,6 +8,9 @@ builder.Services.AddControllers();
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
+
+// Bind the Pathfinder configuration setting (for country adjacency details and starting point)
+builder.Services.Configure<PathfinderConfiguration>(builder.Configuration.GetSection("Pathfinder"));
 
 // Adding our Pathfinder service
 builder.Services.AddScoped<IPathfinderService, PathfinderService>();

--- a/Pathfinder/appsettings.json
+++ b/Pathfinder/appsettings.json
@@ -5,5 +5,19 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
-}
+  "AllowedHosts": "*",
+  "Pathfinder": {
+    "InitialCountry": "USA",
+    "AdjacencyList": {
+      "CAN": [ "USA" ],
+      "USA": [ "CAN", "MEX" ],
+      "MEX": [ "USA", "GTM", "BLZ" ],
+      "BLZ": [ "MEX", "GTM" ],
+      "GTM": [ "MEX", "BLZ", "SLV", "HND" ],
+      "SLV": [ "GTM", "HND" ],
+      "HND": [ "GTM", "SLV", "NIC" ],
+      "NIC": [ "HND", "CRI" ],
+      "CRI": [ "NIC", "PAN" ],
+      "PAN": [ "CRI" ]
+    }
+  }

--- a/Pathfinder_UnitTests/PathfinderControllerTests.cs
+++ b/Pathfinder_UnitTests/PathfinderControllerTests.cs
@@ -4,12 +4,18 @@ namespace Pathfinder_UnitTests
 {
     /// <summary>
     /// These are unit tests for the controller, PathfinderController.
-    /// These are similar to the unit tests for the controller, but we expect HTTP responses and we do not expect exceptions to be thrown.
+    /// These are similar to the unit tests for the controller, but we expect HTTP responses, and we do not expect exceptions to be thrown.
+    /// Note that this is testing the business logic - these tests are currently not isolated to the controller.
     /// </summary>
     public class PathfinderControllerTests
     {
         #region FindPath() Tests
-        public static IEnumerable<object[]> GetPathTestData()
+        /// <summary>
+        /// xUnit tests can use an IEnumerable to provide MemberData for a Theory.
+        /// This is data containing the destination, and the path that should be returned.
+        /// </summary>
+        /// <returns></returns>
+        public static IEnumerable<object[]> GetPathTestData() // todo: see if this can be moved to common setup
         {
             yield return new object[] { "PAN", new List<string> { "USA", "MEX", "GTM", "HND", "NIC", "CRI", "PAN" } };
             yield return new object[] { "BLZ", new List<string> { "USA", "MEX", "BLZ" } };

--- a/Pathfinder_UnitTests/PathfinderControllerTests.cs
+++ b/Pathfinder_UnitTests/PathfinderControllerTests.cs
@@ -7,20 +7,9 @@ namespace Pathfinder_UnitTests
     /// These are similar to the unit tests for the controller, but we expect HTTP responses, and we do not expect exceptions to be thrown.
     /// Note that this is testing the business logic - these tests are currently not isolated to the controller.
     /// </summary>
-    public class PathfinderControllerTests
+    public class PathfinderControllerTests : PathfinderSetup
     {
         #region FindPath() Tests
-        /// <summary>
-        /// xUnit tests can use an IEnumerable to provide MemberData for a Theory.
-        /// This is data containing the destination, and the path that should be returned.
-        /// </summary>
-        /// <returns></returns>
-        public static IEnumerable<object[]> GetPathTestData() // todo: see if this can be moved to common setup
-        {
-            yield return new object[] { "PAN", new List<string> { "USA", "MEX", "GTM", "HND", "NIC", "CRI", "PAN" } };
-            yield return new object[] { "BLZ", new List<string> { "USA", "MEX", "BLZ" } };
-            yield return new object[] { "CAN", new List<string> { "USA", "CAN" } };
-        }
 
         #region Returns 200 Ok
 

--- a/Pathfinder_UnitTests/PathfinderServiceTests.cs
+++ b/Pathfinder_UnitTests/PathfinderServiceTests.cs
@@ -10,6 +10,11 @@ namespace Pathfinder_UnitTests
     {
         #region FindPath() Tests
 
+        /// <summary>
+        /// xUnit tests can use an IEnumerable to provide MemberData for a Theory.
+        /// This is data containing the destination, and the path that should be returned.
+        /// </summary>
+        /// <returns></returns>
         public static IEnumerable<object[]> GetPathTestData()
         {
             yield return new object[] { "PAN", new List<string> { "USA", "MEX", "GTM", "HND", "NIC", "CRI", "PAN" } };

--- a/Pathfinder_UnitTests/PathfinderServiceTests.cs
+++ b/Pathfinder_UnitTests/PathfinderServiceTests.cs
@@ -1,5 +1,3 @@
-using PathfinderApi.Models;
-
 namespace Pathfinder_UnitTests
 {
     /// <summary>
@@ -16,7 +14,7 @@ namespace Pathfinder_UnitTests
         public void FindPath_CountryCode_ReturnsValidPath(string countryCode, List<string> expectedResult)
         {
             // Arrange
-            var pathfinderSvc = new PathfinderService();
+            var pathfinderSvc = GetPathfinderSvc();
 
             // Act
             var result = pathfinderSvc.FindPath(countryCode);
@@ -30,7 +28,7 @@ namespace Pathfinder_UnitTests
         public void FindPath_StartPoint_ReturnsStart()
         {
             // Arrange
-            var pathfinderSvc = new PathfinderService();
+            var pathfinderSvc = GetPathfinderSvc();
             var startLocation = "USA";
 
             // Act
@@ -49,7 +47,7 @@ namespace Pathfinder_UnitTests
         public void FindPath_Null_ThrowsException()
         {
             // Arrange
-            var pathfinderSvc = new PathfinderService();
+            var pathfinderSvc = GetPathfinderSvc();
 
             // Act & Assert
             Assert.Throws<ArgumentNullException>(() => pathfinderSvc.FindPath(null));
@@ -59,7 +57,7 @@ namespace Pathfinder_UnitTests
         public void FindPath_EmptyString_ThrowsException()
         {
             // Arrange
-            var pathfinderSvc = new PathfinderService();
+            var pathfinderSvc = GetPathfinderSvc();
 
             // Act & Assert
             Assert.Throws<ArgumentNullException>(() => pathfinderSvc.FindPath(string.Empty));
@@ -71,7 +69,7 @@ namespace Pathfinder_UnitTests
         public void FindPath_InvalidCountryCodes_ThrowsException(string invalidCountryCode)
         {
             // Arrange
-            var pathfinderSvc = new PathfinderService();
+            var pathfinderSvc = GetPathfinderSvc();
 
             // Act & Assert
             Assert.Throws<ArgumentException>(() => pathfinderSvc.FindPath(invalidCountryCode));

--- a/Pathfinder_UnitTests/PathfinderServiceTests.cs
+++ b/Pathfinder_UnitTests/PathfinderServiceTests.cs
@@ -6,21 +6,9 @@ namespace Pathfinder_UnitTests
     /// This file contains unit tests for our Pathfinder class, which only has the FindPath method
     /// All units tests follow the best practices outlined here: https://learn.microsoft.com/en-us/dotnet/core/testing/unit-testing-best-practices
     /// </summary>
-    public class PathfinderServiceTests
+    public class PathfinderServiceTests : PathfinderSetup
     {
         #region FindPath() Tests
-
-        /// <summary>
-        /// xUnit tests can use an IEnumerable to provide MemberData for a Theory.
-        /// This is data containing the destination, and the path that should be returned.
-        /// </summary>
-        /// <returns></returns>
-        public static IEnumerable<object[]> GetPathTestData()
-        {
-            yield return new object[] { "PAN", new List<string> { "USA", "MEX", "GTM", "HND", "NIC", "CRI", "PAN" } };
-            yield return new object[] { "BLZ", new List<string> { "USA", "MEX", "BLZ" } };
-            yield return new object[] { "CAN", new List<string> { "USA", "CAN" } };
-        }
 
         #region Successes
         [Theory]

--- a/Pathfinder_UnitTests/PathfinderSetup.cs
+++ b/Pathfinder_UnitTests/PathfinderSetup.cs
@@ -1,5 +1,6 @@
-﻿using PathfinderApi.Controllers;
-using PathfinderApi.Models;
+﻿using Microsoft.Extensions.Options;
+using Pathfinder.Models;
+using PathfinderApi.Controllers;
 
 namespace Pathfinder_UnitTests
 {
@@ -7,7 +8,7 @@ namespace Pathfinder_UnitTests
     {
         public static PathfinderController GetController()
         {
-            PathfinderService pathfinderSvc = new();
+            PathfinderService pathfinderSvc = GetPathfinderSvc();
             return new PathfinderController(pathfinderSvc);
         }
 
@@ -21,6 +22,33 @@ namespace Pathfinder_UnitTests
             yield return new object[] { "PAN", new List<string> { "USA", "MEX", "GTM", "HND", "NIC", "CRI", "PAN" } };
             yield return new object[] { "BLZ", new List<string> { "USA", "MEX", "BLZ" } };
             yield return new object[] { "CAN", new List<string> { "USA", "CAN" } };
+        }
+
+        public static IOptions<PathfinderConfiguration> GetConfig()
+        {
+            string initialCountry = "USA";
+            Dictionary<string, List<string>> adjacencyList = new()
+            {
+                ["CAN"] = ["USA"],
+                ["USA"] = ["CAN", "MEX"],
+                ["MEX"] = ["USA", "GTM", "BLZ"],
+                ["BLZ"] = ["MEX", "GTM"],
+                ["GTM"] = ["MEX", "BLZ", "SLV", "HND"],
+                ["SLV"] = ["GTM", "HND"],
+                ["HND"] = ["GTM", "SLV", "NIC"],
+                ["NIC"] = ["HND", "CRI"],
+                ["CRI"] = ["NIC", "PAN"],
+                ["PAN"] = ["CRI"]
+            };
+
+            var config = new PathfinderConfiguration(initialCountry, adjacencyList);
+            return Options.Create(config);
+        }
+
+        public static PathfinderService GetPathfinderSvc()
+        {
+            var config = GetConfig();
+            return new PathfinderService(config);
         }
     }
 }

--- a/Pathfinder_UnitTests/PathfinderSetup.cs
+++ b/Pathfinder_UnitTests/PathfinderSetup.cs
@@ -3,12 +3,24 @@ using PathfinderApi.Models;
 
 namespace Pathfinder_UnitTests
 {
-    public static class PathfinderSetup
+    public class PathfinderSetup
     {
         public static PathfinderController GetController()
         {
             PathfinderService pathfinderSvc = new();
             return new PathfinderController(pathfinderSvc);
+        }
+
+        /// <summary>
+        /// xUnit tests can use an IEnumerable to provide MemberData for a Theory.
+        /// This is data containing the destination, and the path that should be returned.
+        /// </summary>
+        /// <returns></returns>
+        public static IEnumerable<object[]> GetPathTestData()
+        {
+            yield return new object[] { "PAN", new List<string> { "USA", "MEX", "GTM", "HND", "NIC", "CRI", "PAN" } };
+            yield return new object[] { "BLZ", new List<string> { "USA", "MEX", "BLZ" } };
+            yield return new object[] { "CAN", new List<string> { "USA", "CAN" } };
         }
     }
 }


### PR DESCRIPTION
- Updated documentation/comments in code to make sure XML-style comments are present where necessary.
- Moved redundant code in unit test files into common setup file.

**Biggest change: configuration details**
Previously, PathfinderService.cs had some hard-coded details for the implementation of its path-finding. In particular, the adjacency lists for how countries bordered each other (and thus also what countries were available/valid) were manually specified. 

So was the country that any route started in. This was all moved out into configuration in appsettings.json for greater flexibilty.